### PR TITLE
Fix empty login/password in netrc

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -42,7 +42,7 @@ func isTag(event, ref string) bool {
 
 // helper function to write a netrc file.
 func writeNetrc(machine, login, password string) error {
-	if machine == "" || login == "" {
+	if machine == "" || (login == "" && password == "") {
 		return nil
 	}
 	out := fmt.Sprintf(

--- a/utils.go
+++ b/utils.go
@@ -42,7 +42,7 @@ func isTag(event, ref string) bool {
 
 // helper function to write a netrc file.
 func writeNetrc(machine, login, password string) error {
-	if machine == "" {
+	if machine == "" || login == "" {
 		return nil
 	}
 	out := fmt.Sprintf(


### PR DESCRIPTION
The setupScript is:

```go
unset CI_NETRC_USERNAME
unset CI_NETRC_PASSWORD
unset CI_SCRIPT
```

So if the login and password are empty, we should not write the netrc again.
