### PR TITLE
Add basic docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
   </a>
 </p>
 
-Woodpecker/Drone plugin to clone `git` repositories. For the usage information and a listing of the available options please take a look at [the docs](http://plugins.drone.io/drone-plugins/drone-git).
+Woodpecker plugin to clone `git` repositories. For the usage information and a listing of the available options please take a look at [the docs](https://woodpecker-ci.org/plugins/plugin-git).
+The docs are also available in [`docs.md` in this repository](docs.md).
 
 ## Build
 

--- a/docs.md
+++ b/docs.md
@@ -1,7 +1,7 @@
 ---
 name: Git Plugin
 icon: https://woodpecker-ci.org/img/logo.svg
-description: This plugin clones a Git repository.
+description: This is the default plugin for the clone step.
 ---
 
 This plugin is automatically introduced into your pipeline as the first step.

--- a/docs.md
+++ b/docs.md
@@ -28,12 +28,12 @@ clone:
 ```
 
 
-## Options
+## Settings
 
-| Option Name | Default | Description |
-| ----------- | ------: | ----------- |
-| `depth`     |  *none* | If specified, uses git's `--depth` option to create a shallow clone with a limited number of commits. |
-| `lfs`       |  `true` | Set this to `false` to disable retrieval of LFS files. |
+| Settings Name | Default | Description |
+| ------------- | ------: | ----------- |
+| `depth`       |  *none* | If specified, uses git's `--depth` option to create a shallow clone with a limited number of commits. |
+| `lfs`         |  `true` | Set this to `false` to disable retrieval of LFS files. |
 
 
 [pipelineClone]: https://woodpecker-ci.org/docs/usage/pipeline-syntax#clone

--- a/docs.md
+++ b/docs.md
@@ -1,0 +1,40 @@
+---
+name: Git Plugin
+icon: https://woodpecker-ci.org/img/logo.svg
+description: This plugin clones a Git repository.
+---
+
+This plugin is automatically introduced into your pipeline as the first step.
+Its purpose is to clone your Git repository.
+
+## Features
+
+- Git LFS support is enabled by default.
+
+
+## Overriding Settings
+
+You can manually define your `clone` step in order to change plugin or override some of the default settings.
+Consult [the `clone` section of the pipeline documentation][pipelineClone] for more information;
+this documentation page only describes this plugin.
+
+```yaml
+clone:
+  git:
+    image: woodpeckerci/plugin-git
+  settings:
+    depth: 50
+    lfs: false
+```
+
+
+## Options
+
+| Option Name | Default | Description |
+| ----------- | ------: | ----------- |
+| `depth`     |  *none* | If specified, uses git's `--depth` option to create a shallow clone with a limited number of commits. |
+| `lfs`       |  `true` | Set this to `false` to disable retrieval of LFS files. |
+
+
+[pipelineClone]: https://woodpecker-ci.org/docs/usage/pipeline-syntax#clone
+

--- a/docs.md
+++ b/docs.md
@@ -10,7 +10,8 @@ Its purpose is to clone your Git repository.
 ## Features
 
 - Git LFS support is enabled by default.
-
+- Fetch tags when needed.
+- Ajust submodules.
 
 ## Overriding Settings
 
@@ -27,14 +28,20 @@ clone:
     lfs: false
 ```
 
-
 ## Settings
 
-| Settings Name | Default | Description |
-| ------------- | ------: | ----------- |
-| `depth`       |  *none* | If specified, uses git's `--depth` option to create a shallow clone with a limited number of commits. |
-| `lfs`         |  `true` | Set this to `false` to disable retrieval of LFS files. |
-
+| Settings Name             | Default | Description
+| --------------------------| ------- | --------------------------------------------
+| `depth`                   | *none*  | If specified, uses git's `--depth` option to create a shallow clone with a limited number of commits
+| `lfs`                     | `true`  | Set this to `false` to disable retrieval of LFS files
+| `recursive`               | `false` | Clones submodules recursively
+| `skip_verify`             | `false` | Skips the SSL verification
+| `tags`                    | `false` | Fetches tags when set to true
+| `submodule_overrides`     | *none*  | Override submodule urls
+| `submodule_update_remote` | `false` | Pass the --remote flag to git submodule update
+| `custom_ssl_path`         | *none*  | Set path to custom cert
+| `custom_ssl_url`          | *none*  | Set url to custom cert
+| `backoff`                 | `5sec`  | Change backoff duration
+| `attempts`                | `5`     | Change backoff attempts
 
 [pipelineClone]: https://woodpecker-ci.org/docs/usage/pipeline-syntax#clone
-


### PR DESCRIPTION
I don't know if you would say that this 'fixes' #16 or just makes a baby step towards it, but at least it's hopefully something?

I've included the LFS #22 option even though we haven't implemented it yet — I'll implement it shortly (if I can figure out how to speak enough Go!).

[Rendered](https://github.com/reivilibre/plugin-git/blob/rei/docs/docs.md)