### PR TITLE
Do not set GIT_TERMINAL_PROMPT=0 for git

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -26,7 +26,7 @@ type Plugin struct {
 const customCertTmpPath = "/tmp/customCert.pem"
 
 var defaultEnvVars = []string{
-	"GIT_TERMINAL_PROMPT=0", // don't wait for user input
+	// do not set GIT_TERMINAL_PROMPT=0, otherwise git won't load credentials from ".netrc" 
 	"GIT_LFS_SKIP_SMUDGE=1", // prevents git-lfs from retrieving any LFS files
 }
 

--- a/plugin.go
+++ b/plugin.go
@@ -26,7 +26,7 @@ type Plugin struct {
 const customCertTmpPath = "/tmp/customCert.pem"
 
 var defaultEnvVars = []string{
-	// do not set GIT_TERMINAL_PROMPT=0, otherwise git won't load credentials from ".netrc" 
+	// do not set GIT_TERMINAL_PROMPT=0, otherwise git won't load credentials from ".netrc"
 	"GIT_LFS_SKIP_SMUDGE=1", // prevents git-lfs from retrieving any LFS files
 }
 


### PR DESCRIPTION
Do not set GIT_TERMINAL_PROMPT=0, otherwise git won't use credentials from ".netrc".

* plugin-git:v1.4.0: git cloning from private repo works.
* plugin-git:v1.5.0: git cloning from private repo doesn't work and reports:  "fatal: could not read Username for 'https://my-repo.com': terminal prompts disabled"

The diff: https://github.com/woodpecker-ci/plugin-git/compare/v1.4.0...v1.5.0

Although it's not well documented, but according to: https://snippets.aktagon.com/snippets/909-fixing-go-get-and-terminal-prompts-disabled-when-pulling-private-and-public-repos-from-gitlab , it seems that git need the "terminal prompt" to use credentials from ".netrc".

----

Or, an alternative is to force setting "GIT_TERMINAL_PROMPT=1", while I think it's not necessary to do that, it's better to leave the chance to end users.

