### PR TITLE
fix: write .netrc location with home var

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/adrg/xdg"
 	"github.com/urfave/cli/v2"
 )
 
@@ -25,5 +26,10 @@ func SetDefaults(c *cli.Context, p *Plugin) {
 	if p.Config.Partial {
 		p.Config.Depth = 1
 		p.Config.filter = "tree:0"
+	}
+
+	if len(p.Config.Home) == 0 {
+		// fallback to system home
+		p.Config.Home = xdg.Home
 	}
 }

--- a/plugin.go
+++ b/plugin.go
@@ -11,8 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/adrg/xdg"
 )
 
 type Plugin struct {
@@ -38,7 +36,7 @@ func (p Plugin) Exec() error {
 		}
 	}
 
-	err := writeNetrc(p.Netrc.Machine, p.Netrc.Login, p.Netrc.Password)
+	err := writeNetrc(p.Config.Home, p.Netrc.Machine, p.Netrc.Login, p.Netrc.Password)
 	if err != nil {
 		return err
 	}
@@ -327,11 +325,6 @@ func remapSubmodule(name, url string) *exec.Cmd {
 }
 
 func setHome(home string) error {
-	if len(home) == 0 {
-		// fallback to system home
-		home = xdg.Home
-	}
-
 	// make sure home dir exist and is set
 	homeExist, err := pathExists(home)
 	if err != nil {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -142,6 +142,7 @@ func TestClone(t *testing.T) {
 			Config: Config{
 				Recursive: c.recursive,
 				Lfs:       c.lfs,
+				Home:      "/tmp",
 			},
 		}
 
@@ -188,6 +189,7 @@ func TestCloneNonEmpty(t *testing.T) {
 			Config: Config{
 				Recursive: c.recursive,
 				Lfs:       c.lfs,
+				Home:      "/tmp",
 			},
 		}
 

--- a/utils.go
+++ b/utils.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"strings"
 )
@@ -53,7 +52,7 @@ func isTag(event, ref string) bool {
 }
 
 // helper function to write a netrc file.
-func writeNetrc(machine, login, password string) error {
+func writeNetrc(home, machine, login, password string) error {
 	if machine == "" || (login == "" && password == "") {
 		return nil
 	}
@@ -64,11 +63,6 @@ func writeNetrc(machine, login, password string) error {
 		password,
 	)
 
-	home := "/root"
-	u, err := user.Current()
-	if err == nil {
-		home = u.HomeDir
-	}
 	path := filepath.Join(home, ".netrc")
 	return ioutil.WriteFile(path, []byte(out), 0o600)
 }


### PR DESCRIPTION
Fix https://github.com/woodpecker-ci/woodpecker/issues/1473, No such device or address on git fetch

Bug of #47, .netrc is not written in home override location.
Default and override config home are working
