### PR TITLE
Fix "plugin-git": executable file not found

### DIFF
--- a/docker/Dockerfile.multiarch
+++ b/docker/Dockerfile.multiarch
@@ -16,4 +16,4 @@ ENV GODEBUG=netdns=go
 ENV PLUGIN_HOME=$HOME
 
 COPY --from=build src/release/plugin-git /bin/
-ENTRYPOINT ["/bin/plugin-git"]
+ENTRYPOINT [ "sh", "-c", "/bin/plugin-git" ]


### PR DESCRIPTION
adapt Dockerfile entrypoint to "shell form"

