### PR TITLE
Add os.Environ() for git commands environments

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -41,6 +41,9 @@ func (p Plugin) Exec() error {
 		return err
 	}
 
+	// set vars from exec environment
+	defaultEnvVars = append(os.Environ(), defaultEnvVars...)
+
 	// alter home var for all commands exec afterwards
 	if err := setHome(p.Config.Home); err != nil {
 		return err


### PR DESCRIPTION
I run the local agent on NixOS, and without this fix the commands lose their `PATH` which means they can't execute any external tool (e.g: `uname` which is needed by some git commands, `git-lfs`)