### PR TITLE
Add git `safe.directory` support

### DIFF
--- a/docker/Dockerfile.multiarch
+++ b/docker/Dockerfile.multiarch
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.18 AS build
+FROM --platform=$BUILDPLATFORM golang:1.20 AS build
 ARG TARGETOS TARGETARCH
 
 WORKDIR /src

--- a/main.go
+++ b/main.go
@@ -135,6 +135,12 @@ func main() {
 			Usage:   "Change home directory",
 			EnvVars: []string{"PLUGIN_HOME"},
 		},
+		&cli.StringFlag{
+			Name:    "safe-directory",
+			Usage:   "Define safe directories",
+			EnvVars: []string{"PLUGIN_SAFE_DIRECTORY"},
+			Value:   "*",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -174,6 +180,7 @@ func run(c *cli.Context) error {
 			Branch:          c.String("branch"),
 			Partial:         c.Bool("partial"),
 			Home:            c.String("home"),
+			SafeDirectory:   c.String("safe-directory"),
 		},
 		Backoff: Backoff{
 			Attempts: c.Int("backoff-attempts"),

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func main() {
 			Name:    "safe-directory",
 			Usage:   "Define safe directories",
 			EnvVars: []string{"PLUGIN_SAFE_DIRECTORY"},
-			Value:   "*",
+			Value:   "$CI_WORKSPACE",
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -138,8 +138,7 @@ func main() {
 		&cli.StringFlag{
 			Name:    "safe-directory",
 			Usage:   "Define safe directories",
-			EnvVars: []string{"PLUGIN_SAFE_DIRECTORY"},
-			Value:   "$CI_WORKSPACE",
+			EnvVars: []string{"PLUGIN_SAFE_DIRECTORY", "CI_WORKSPACE"},
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -207,7 +207,7 @@ func initGit(branch string) *exec.Cmd {
 }
 
 func safeDirectory(safeDirectory string) *exec.Cmd {
-	return appendEnv(exec.Command("git", "config", "--global", "safe.directory", os.ExpandEnv(safeDirectory)), defaultEnvVars...)
+	return appendEnv(exec.Command("git", "config", "safe.directory", os.ExpandEnv(safeDirectory)), defaultEnvVars...)
 }
 
 // Sets the remote origin for the repository.

--- a/plugin.go
+++ b/plugin.go
@@ -207,7 +207,7 @@ func initGit(branch string) *exec.Cmd {
 }
 
 func safeDirectory(safeDirectory string) *exec.Cmd {
-	return appendEnv(exec.Command("git", "config", "safe.directory", safeDirectory), defaultEnvVars...)
+	return appendEnv(exec.Command("git", "config", "--global", "safe.directory", safeDirectory), defaultEnvVars...)
 }
 
 // Sets the remote origin for the repository.

--- a/plugin.go
+++ b/plugin.go
@@ -207,7 +207,7 @@ func initGit(branch string) *exec.Cmd {
 }
 
 func safeDirectory(safeDirectory string) *exec.Cmd {
-	return appendEnv(exec.Command("git", "config", "safe.directory", os.ExpandEnv(safeDirectory)), defaultEnvVars...)
+	return appendEnv(exec.Command("git", "config", "safe.directory", safeDirectory), defaultEnvVars...)
 }
 
 // Sets the remote origin for the repository.

--- a/plugin.go
+++ b/plugin.go
@@ -62,6 +62,7 @@ func (p Plugin) Exec() error {
 
 	if isDirEmpty(filepath.Join(p.Build.Path, ".git")) {
 		cmds = append(cmds, initGit(p.Config.Branch))
+		cmds = append(cmds, safeDirectory(p.Config.SafeDirectory))
 		cmds = append(cmds, remote(p.Repo.Clone))
 	}
 
@@ -203,6 +204,14 @@ func initGit(branch string) *exec.Cmd {
 		return appendEnv(exec.Command("git", "init"), defaultEnvVars...)
 	}
 	return appendEnv(exec.Command("git", "init", "-b", branch), defaultEnvVars...)
+}
+
+func safeDirectory(safeDirectory string) *exec.Cmd {
+	if safeDirectory != "" {
+		return appendEnv(exec.Command("git", "config", "--global", "safe.directory", safeDirectory), defaultEnvVars...)
+	} else {
+		return nil
+	}
 }
 
 // Sets the remote origin for the repository.

--- a/plugin.go
+++ b/plugin.go
@@ -207,11 +207,7 @@ func initGit(branch string) *exec.Cmd {
 }
 
 func safeDirectory(safeDirectory string) *exec.Cmd {
-	if safeDirectory != "" {
-		return appendEnv(exec.Command("git", "config", "--global", "safe.directory", safeDirectory), defaultEnvVars...)
-	} else {
-		return nil
-	}
+	return appendEnv(exec.Command("git", "config", "--global", "safe.directory", os.ExpandEnv(safeDirectory)), defaultEnvVars...)
 }
 
 // Sets the remote origin for the repository.

--- a/types.go
+++ b/types.go
@@ -37,6 +37,7 @@ type (
 		Home            string
 		Partial         bool
 		filter          string
+		SafeDirectory   string
 	}
 
 	Backoff struct {


### PR DESCRIPTION
fix #63 

- Add support for `git config safe.directory`
- Enabled by default for the directory which is being cloned (imo this should be what users want/expect)
- Default is set to `$CI_WORKSPACE` but can be adjusted via env var `PLUGIN_SAFE_DIRECTORY`

Works for me with image `pats22/plugin-git:2.0.13` (based on `plugin-git:2.0.3`)

```
+ git init -b main
Initialized empty Git repository in /woodpecker/src/gitea.<owner>.com/<owner>/<repo>/.git/
+ git config --global safe.directory /woodpecker/src/gitea.<owner>.com/<owner>/<repo>
+ git remote add origin https://gitea.<owner>.com/<owner>/<repo>.git
```