### PR TITLE
Add option to use SSH for cloning repo

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,6 +140,22 @@ func main() {
 			Usage:   "Define safe directories",
 			EnvVars: []string{"PLUGIN_SAFE_DIRECTORY", "CI_WORKSPACE"},
 		},
+		&cli.BoolFlag{
+			Name:    "use-ssh",
+			Usage:   "Using ssh for git clone",
+			EnvVars: []string{"PLUGIN_USE_SSH"},
+			Value:   false,
+		},
+		&cli.StringFlag{
+			Name:    "ssh-key",
+			Usage:   "SSH key for ssh clone",
+			EnvVars: []string{"PLUGIN_SSH_KEY"},
+		},
+		&cli.StringFlag{
+			Name:    "forge-url",
+			Usage:   "Forge URL for ssh clone",
+			EnvVars: []string{"CI_FORGE_URL"},
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -155,6 +171,7 @@ func run(c *cli.Context) error {
 	plugin := Plugin{
 		Repo: Repo{
 			Clone: c.String("remote"),
+			Forge: c.String("forge-url"),
 		},
 		Build: Build{
 			Commit: c.String("sha"),
@@ -180,6 +197,8 @@ func run(c *cli.Context) error {
 			Partial:         c.Bool("partial"),
 			Home:            c.String("home"),
 			SafeDirectory:   c.String("safe-directory"),
+			UseSSH: 	 	 c.Bool("use-ssh"),
+			SSHKey: 	 	 c.String("ssh-key"),
 		},
 		Backoff: Backoff{
 			Attempts: c.Int("backoff-attempts"),

--- a/main.go
+++ b/main.go
@@ -197,8 +197,8 @@ func run(c *cli.Context) error {
 			Partial:         c.Bool("partial"),
 			Home:            c.String("home"),
 			SafeDirectory:   c.String("safe-directory"),
-			UseSSH: 	 	 c.Bool("use-ssh"),
-			SSHKey: 	 	 c.String("ssh-key"),
+			UseSSH:          c.Bool("use-ssh"),
+			SSHKey:          c.String("ssh-key"),
 		},
 		Backoff: Backoff{
 			Attempts: c.Int("backoff-attempts"),

--- a/plugin.go
+++ b/plugin.go
@@ -226,7 +226,6 @@ func useSSH(forgeURL string) *exec.Cmd {
 	return appendEnv(exec.Command("git", "config", fmt.Sprintf("url.git@%s:.insteadOf", remoteURL), forgeURL+"/"), defaultEnvVars...)
 }
 
-
 // Sets the remote origin for the repository.
 func remote(remote string) *exec.Cmd {
 	return appendEnv(exec.Command(

--- a/types.go
+++ b/types.go
@@ -39,8 +39,8 @@ type (
 		Partial         bool
 		filter          string
 		SafeDirectory   string
-		UseSSH	 		bool
-		SSHKey			string
+		UseSSH          bool
+		SSHKey          string
 	}
 
 	Backoff struct {

--- a/types.go
+++ b/types.go
@@ -8,6 +8,7 @@ import (
 type (
 	Repo struct {
 		Clone string
+		Forge string
 	}
 
 	Build struct {
@@ -38,6 +39,8 @@ type (
 		Partial         bool
 		filter          string
 		SafeDirectory   string
+		UseSSH	 		bool
+		SSHKey			string
 	}
 
 	Backoff struct {


### PR DESCRIPTION
Setting `PLUGIN_USE_SSH` env var to true enables SSH cloning
Setting `PLUGIN_USE_SSH` env var to the path of a custom SSH Key

closes #58