### PR TITLE
Add renovate config

### DIFF
--- a/.woodpecker/release.yml
+++ b/.woodpecker/release.yml
@@ -4,7 +4,7 @@ when:
 
 steps:
   release:
-    image: woodpeckerci/plugin-ready-release-go
+    image: woodpeckerci/plugin-ready-release-go:0.6.1
     pull: true
     settings:
       release_branch: ${CI_REPO_DEFAULT_BRANCH}

--- a/.woodpecker/test-release.yml
+++ b/.woodpecker/test-release.yml
@@ -39,7 +39,7 @@ steps:
       - make test
 
   build-dryrun:
-    image: woodpeckerci/plugin-docker-buildx:2
+    image: woodpeckerci/plugin-docker-buildx:2.1.0
     settings:
       repo: test/repo
       dockerfile: ./docker/Dockerfile.multiarch
@@ -50,7 +50,7 @@ steps:
       event: pull_request
 
   release-next:
-    image: woodpeckerci/plugin-docker-buildx:2
+    image: woodpeckerci/plugin-docker-buildx:2.1.0
     settings:
       repo: *publish_repos
       dockerfile: ./docker/Dockerfile.multiarch
@@ -62,7 +62,7 @@ steps:
       event: push
 
   release-tag:
-    image: woodpeckerci/plugin-docker-buildx:2
+    image: woodpeckerci/plugin-docker-buildx:2.1.0
     settings:
       repo: *publish_repos
       dockerfile: ./docker/Dockerfile.multiarch
@@ -83,7 +83,7 @@ steps:
       event: tag
 
   release-binarys:
-    image: plugins/github-release
+    image: plugins/github-release:latest
     settings:
       files:
         - release/*

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":maintainLockFilesWeekly"],
+  "prConcurrentLimit": 5,
+  "packageRules": [
+    {
+      "matchManagers": ["gomod", "dockerfile"],
+      "labels": ["dependencies"]
+    },
+    {
+      "matchManagers": ["woodpecker"],
+      "labels": ["build"]
+    }
+  ]
+}


### PR DESCRIPTION
Skipping `plugins/github-release` since the last released tagged with a semver is 4 years old 😢 