### PR TITLE
Fix alpine version to 3.18

### DIFF
--- a/docker/Dockerfile.multiarch
+++ b/docker/Dockerfile.multiarch
@@ -7,7 +7,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     make build
 
-FROM alpine:edge
+FROM alpine:3.18
 ARG HOME=/app
 
 RUN mkdir -p $HOME


### PR DESCRIPTION
Or is `edge` really needed?