### PR TITLE
Reduce image platforms

### DIFF
--- a/.woodpecker/test-release.yml
+++ b/.woodpecker/test-release.yml
@@ -1,6 +1,6 @@
 variables:
   - &golang 'golang:1.20-alpine'
-  - &platforms 'linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/riscv64,linux/s390x'
+  - &platforms 'linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x'
   # vars used on push / tag events only
   - publish_logins: &publish_logins
       # Default DockerHub login

--- a/.woodpecker/test-release.yml
+++ b/.woodpecker/test-release.yml
@@ -1,6 +1,6 @@
 variables:
   - &golang 'golang:1.20-alpine'
-  - &platforms 'linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x'
+  - &platforms 'linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/riscv64,linux/s390x'
   # vars used on push / tag events only
   - publish_logins: &publish_logins
       # Default DockerHub login


### PR DESCRIPTION
`riscv64` does not even have a alpine build for the latest release.
I guess we don't need to support all exotic platforms? Also arm/v6 is quite old and probably not used by anyone anymore.

Fixes issues in #90 