### PR TITLE
Use `depends_on`

### DIFF
--- a/.woodpecker/test-release.yml
+++ b/.woodpecker/test-release.yml
@@ -62,7 +62,6 @@ steps:
       - event: push
         branch: renovate/*
 
-
   release-next:
     image: woodpeckerci/plugin-docker-buildx:2.2.1
     depends_on:


### PR DESCRIPTION
and update config to run on renovate branches and don't execute lint/test on PR