### PR TITLE
Correct config options' names in `docs.md`

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -42,24 +42,24 @@ clone:
 | `depth`                   | _none_                              | If specified, uses git's `--depth` option to create a shallow clone with a limited number of commits, overwritten by partial            |
 | `lfs`                     | `true`                              | Set this to `false` to disable retrieval of LFS files                                                                                   |
 | `recursive`               | `false`                             | Clones submodules recursively                                                                                                           |
-| `skip_verify`             | `false`                             | Skips the SSL verification                                                                                                              |
+| `skip-verify`             | `false`                             | Skips the SSL verification                                                                                                              |
 | `tags`                    | `false` (except on tag event)       | Fetches tags when set to true, default is false if event is not tag else true                                                           |
-| `submodule_overrides`     | _none_                              | Override submodule urls                                                                                                                 |
-| `submodule_update_remote` | `false`                             | Pass the --remote flag to git submodule update                                                                                          |
-| `submodule_partial`       | `true`                              | Update submodules via partial clone (depth=1)                                                                                           |
-| `custom_ssl_path`         | _none_                              | Set path to custom cert                                                                                                                 |
-| `custom_ssl_url`          | _none_                              | Set url to custom cert                                                                                                                  |
+| `submodule-overrides`     | _none_                              | Override submodule urls                                                                                                                 |
+| `submodule-update-remote` | `false`                             | Pass the --remote flag to git submodule update                                                                                          |
+| `submodule-partial`       | `true`                              | Update submodules via partial clone (depth=1)                                                                                           |
+| `custom-ssl-path`         | _none_                              | Set path to custom cert                                                                                                                 |
+| `custom-ssl-url`          | _none_                              | Set url to custom cert                                                                                                                  |
 | `backoff`                 | `5sec`                              | Change backoff duration                                                                                                                 |
 | `attempts`                | `5`                                 | Change backoff attempts                                                                                                                 |
 | `branch`                  | $CI_COMMIT_BRANCH                   | Change branch name to checkout to                                                                                                       |
 | `partial`                 | `true` (except if tags are fetched) | Only fetch the one commit and it's blob objects to resolve all files, overwrite depth with 1                                            |
 | `home`                    |                                     | Change HOME var for commands executed, fail if it does not exist                                                                        |
 | `remote`                  | $CI_REPO_CLONE_URL                  | Set the git remote url                                                                                                                  |
-| `remote_ssh`              | $CI_REPO_CLONE_SSH_URL              | Set the git SSH remote url                                                                                                              |
+| `remote-ssh`              | $CI_REPO_CLONE_SSH_URL              | Set the git SSH remote url                                                                                                              |
 | `sha`                     | $CI_COMMIT_SHA                      | git commit hash to retrieve (use `sha: ''` to clone the `ref`)                                                                          |
 | `ref`                     | $CI_COMMIT_REF                      | Set the git reference to retrieve (use `ref: refs/heads/a_branch` and `sha: ''` to retrieve the head commit from the "a_branch" branch) |
 | `path`                    | $CI_WORKSPACE                       | Set destination path to clone to                                                                                                        |
-| `use_ssh`                 | `false`                             | Clone using SSH                                                                                                                         |
-| `ssh_key`                 | _none_                              | SSH key for SSH clone                                                                                                                   |
+| `use-ssh`                 | `false`                             | Clone using SSH                                                                                                                         |
+| `ssh-key`                 | _none_                              | SSH key for SSH clone                                                                                                                   |
 
 [workflowClone]: https://woodpecker-ci.org/docs/usage/workflow-syntax#clone


### PR DESCRIPTION
They all have hyphens in the config processing code, not underscores.
