### PR TITLE
docs: fix typo in plugin feature description

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -18,7 +18,7 @@ Its purpose is to clone your Git repository.
 
 - Git LFS support is enabled by default.
 - Fetch tags when needed.
-- Ajust submodules.
+- Adjust submodules.
 
 ## Overriding Settings
 


### PR DESCRIPTION
As it says on the time, just fixes a small typo.