### PR TITLE
Use alpine release to fix tag fetching

### DIFF
--- a/docker/Dockerfile.multiarch
+++ b/docker/Dockerfile.multiarch
@@ -4,10 +4,10 @@ ARG TARGETOS TARGETARCH
 WORKDIR /src
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    --mount=type=cache,target=/go/pkg \
-    make build
+  --mount=type=cache,target=/go/pkg \
+  make build
 
-FROM alpine:edge
+FROM alpine:3.21
 ARG HOME=/app
 
 ENV GODEBUG=netdns=go


### PR DESCRIPTION
fix #205 

Presumably, `edge` had some issues at the time of building the latest release image.

Built locally and verified that tag fetching works again.