### PR TITLE
Ensure fs mode for path is set correctly

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -34,6 +34,9 @@ func (p Plugin) Exec() error {
 		if err != nil {
 			return err
 		}
+
+		// Ensure fs mode for path
+		os.Chmod(p.Pipeline.Path, 0o777)
 	}
 
 	err := writeNetrc(p.Config.Home, p.Netrc.Machine, p.Netrc.Login, p.Netrc.Password)

--- a/plugin.go
+++ b/plugin.go
@@ -35,7 +35,7 @@ func (p Plugin) Exec() error {
 			return err
 		}
 
-		// Ensure fs mode for path
+		// Ensure correct mode if path already existed
 		os.Chmod(p.Pipeline.Path, 0o777)
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/woodpecker-ci/woodpecker/issues/5017

As discussed in https://github.com/woodpecker-ci/woodpecker/issues/5017 the Docker `WorkDir` is created automatically if it doesn't exist. As we set the `WorkDir`  https://github.com/woodpecker-ci/woodpecker/blob/main/pipeline/frontend/yaml/compiler/convert.go#L99 basically to `workspaceBase+workspacePath` it already exists before the clone plugin creates it, thus `0777` is not set correctly.