### PR TITLE
Fix plugin URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   </a>
 </p>
 
-Woodpecker plugin to clone `git` repositories. For the usage information and a listing of the available options please take a look at [the docs](https://woodpecker-ci.org/plugins/Git%20Clone).
+Woodpecker plugin to clone `git` repositories. For the usage information and a listing of the available options please take a look at [the docs](https://woodpecker-ci.org/plugins/git-clone).
 The docs are also available in [`docs.md` in this repository](docs.md).
 
 ## Build


### PR DESCRIPTION
The plugin URL was pointing to an invalid (404) page. This is the correct link.