### PR TITLE
Make ssh config global so it is not persisted

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -308,7 +308,7 @@ func sshKeyHandler(sshKey string, knownHosts string) *exec.Cmd {
 	if knownHosts != "" {
 		hostKeyArg = " -o UserKnownHostsFile=" + knownHosts
 	}
-	return appendEnv(exec.Command("git", "config", "core.sshCommand", "ssh -i "+sshKey+hostKeyArg), defaultEnvVars...)
+	return appendEnv(exec.Command("git", "config", "--global", "core.sshCommand", "ssh -i "+sshKey+hostKeyArg), defaultEnvVars...)
 }
 
 // Sets the remote origin for the repository.


### PR DESCRIPTION
I thought about cleaning up afterwards, but I suppose we can just set the config globally so that it is not persisted in the workspace.

Fixes https://github.com/woodpecker-ci/plugin-git/issues/307