### PR TITLE
Revert pre-commit downgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         exclude: '^CHANGELOG.md$'
         language_version: 24.14.0
   - repo: https://github.com/mrtazz/checkmake
-    rev: v0.3.0
+    rev: v0.3.2
     hooks:
       - id: checkmake
   - repo: https://github.com/hadolint/hadolint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ ci:
   autofix_prs: true
   autoupdate_branch: ''
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
-  autoupdate_schedule: monthly
+  autoupdate_schedule: quarterly
   # NB: hadolint not included in pre-commit.ci
   skip: [check-hooks-apply, check-useless-excludes, hadolint, golangci-lint]
   submodules: false


### PR DESCRIPTION
Reverts woodpecker-ci/plugin-git#342

the pre-commit updater is broken. @6543 merged a downgrade.