### PR TITLE
Create Dockerfile.debian

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.idea
+docker/

--- a/.woodpecker/test-release.yml
+++ b/.woodpecker/test-release.yml
@@ -14,7 +14,10 @@ variables:
         password:
           from_secret: QUAY_IO_TOKEN
   - &publish_repos 'woodpeckerci/plugin-git,quay.io/woodpeckerci/plugin-git'
-
+matrix:
+  DOCKERFILE:
+    - multiarch
+    - debian
 steps:
   vendor:
     image: *golang
@@ -51,7 +54,7 @@ steps:
       - test
     settings:
       repo: test/repo
-      dockerfile: ./docker/Dockerfile.multiarch
+      dockerfile: ./docker/Dockerfile.${DOCKERFILE}
       dry_run: true
       platforms: linux/amd64
       tags: latest
@@ -65,7 +68,7 @@ steps:
     depends_on: vendor
     settings:
       repo: *publish_repos
-      dockerfile: ./docker/Dockerfile.multiarch
+      dockerfile: ./docker/Dockerfile.${DOCKERFILE}
       platforms: *platforms
       tags: next
       logins: *publish_logins
@@ -78,7 +81,7 @@ steps:
     depends_on: vendor
     settings:
       repo: *publish_repos
-      dockerfile: ./docker/Dockerfile.multiarch
+      dockerfile: ./docker/Dockerfile.${DOCKERFILE}
       platforms: *platforms
       auto_tag: true
       # remove line below if you can read it on a release branch and it's not the latest release branch

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -1,0 +1,41 @@
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.25 AS build
+ARG TARGETOS TARGETARCH
+
+WORKDIR /src
+COPY . .
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        make \
+        ca-certificates \
+        curl \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN make build
+
+FROM docker.io/library/debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        git-lfs \
+        openssh-client \
+        ca-certificates \
+        curl \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG HOME=/app
+
+ENV GODEBUG=netdns=go
+ENV PLUGIN_HOME=$HOME
+
+RUN mkdir -p $HOME
+
+COPY --from=build /src/release/plugin-git /bin/
+
+ENTRYPOINT ["/bin/plugin-git"]


### PR DESCRIPTION
add debian dockerfile

https://bell-sw.com/blog/how-to-deal-with-alpine-dns-issues/

Switch base image from Alpine to Debian-slim

Alpine's musl libc cannot resolve certain DNS responses (NXDOMAIN + CNAME mixed),
causing git/ssh to fail with "Could not resolve hostname" despite nslookup working.
Debian uses glibc which handles DNS properly with TCP fallback.

Fixes: git clone over SSH failing in pipeline