### PR TITLE
Fix git flag names

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -188,11 +188,11 @@ var globalFlags = []cli.Flag{
 	&cli.StringFlag{
 		Name:    "git-user-name",
 		Usage:   "Git username when merging pull request",
-		Sources: cli.EnvVars("PLUGIN_GIT_USERNAME"),
+		Sources: cli.EnvVars("PLUGIN_GIT_USER_NAME"),
 	},
 	&cli.StringFlag{
 		Name:    "git-user-email",
 		Usage:   "Git user email when merging pull request",
-		Sources: cli.EnvVars("PLUGIN_GIT_USEREMAIL"),
+		Sources: cli.EnvVars("PLUGIN_GIT_USER_EMAIL"),
 	},
 }


### PR DESCRIPTION
As docs say that the flags are called `user-email`/`user-name` we can rename the env vars, but it's not a breaking change – it's just adopting to docs I would say

fix #375 