### PR TITLE
Fix netrc not being picked up on Windows local agents

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
+	"os"
 
-	"github.com/adrg/xdg"
 	"github.com/urfave/cli/v3"
 )
 
@@ -29,7 +29,10 @@ func SetDefaults(c *cli.Command, p *Plugin) {
 	}
 
 	if len(p.Config.Home) == 0 {
-		// fallback to system home
-		p.Config.Home = xdg.Home
+		if home := os.Getenv("HOME"); home != "" {
+			p.Config.Home = home
+		} else if home, err := os.UserHomeDir(); err == nil {
+			p.Config.Home = home
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,6 @@ go 1.22
 toolchain go1.27.1
 
 require (
-	github.com/adrg/xdg v0.5.3
 	github.com/joho/godotenv v1.5.1
 	github.com/urfave/cli/v3 v3.11.0
 )
-
-require golang.org/x/sys v0.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
-github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
@@ -10,7 +8,5 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/urfave/cli/v3 v3.11.0 h1:P/euJp99kb9p0tlVY+iYTLYYTAQlfl0hR2gUO1Img1Q=
 github.com/urfave/cli/v3 v3.11.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
-golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
-golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/plugin.go
+++ b/plugin.go
@@ -22,7 +22,7 @@ type Plugin struct {
 	Backoff  Backoff
 }
 
-const customCertTmpPath = "/tmp/customCert.pem"
+var customCertTmpPath = filepath.Join(os.TempDir(), "customCert.pem")
 
 var defaultEnvVars = []string{
 	// do not set GIT_TERMINAL_PROMPT=0, otherwise git won't load credentials from ".netrc"

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -200,6 +201,8 @@ var commits = []struct {
 // TestClone tests the ability to clone a specific commit into
 // a fresh, empty directory every time.
 func TestClone(t *testing.T) {
+	disableAutoCRLF(t)
+
 	for _, c := range commits {
 
 		dir := setup()
@@ -218,7 +221,7 @@ func TestClone(t *testing.T) {
 			Config: Config{
 				Recursive:         c.recursive,
 				Lfs:               c.lfs,
-				Home:              "/tmp",
+				Home:              os.TempDir(),
 				Branch:            c.branch,
 				TargetBranch:      c.targetbranch,
 				MergePullRequest:  c.mergepullrequest,
@@ -260,6 +263,8 @@ func TestClone(t *testing.T) {
 // a non-empty directory. This is useful if the git workspace is cached
 // and re-stored for every workflow.
 func TestCloneNonEmpty(t *testing.T) {
+	disableAutoCRLF(t)
+
 	dir := setup()
 	defer teardown(dir)
 
@@ -278,7 +283,7 @@ func TestCloneNonEmpty(t *testing.T) {
 			Config: Config{
 				Recursive: c.recursive,
 				Lfs:       c.lfs,
-				Home:      "/tmp",
+				Home:      os.TempDir(),
 				Branch:    c.branch,
 			},
 		}
@@ -305,6 +310,10 @@ func TestCloneNonEmpty(t *testing.T) {
 }
 
 func TestUmaskApplied(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("umask is a no-op on Windows")
+	}
+
 	// set a zero umask to make sure the cloned files are created with the
 	// permissions we specify in the plugin config.
 	oldUmask := umask(0)
@@ -324,7 +333,7 @@ func TestUmaskApplied(t *testing.T) {
 		},
 		Config: Config{
 			Umask:  0o22,
-			Home:   "/tmp",
+			Home:   os.TempDir(),
 			Branch: "master",
 		},
 	}
@@ -344,6 +353,10 @@ func TestUmaskApplied(t *testing.T) {
 }
 
 func TestUmaskZero(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("umask is a no-op on Windows")
+	}
+
 	oldUmask := umask(0o22) // set a non-zero umask before the test
 	defer umask(oldUmask)
 
@@ -361,7 +374,7 @@ func TestUmaskZero(t *testing.T) {
 		},
 		Config: Config{
 			Umask:  0,
-			Home:   "/tmp",
+			Home:   os.TempDir(),
 			Branch: "master",
 		},
 	}
@@ -647,7 +660,7 @@ func TestUpdateSubmodulesRemote(t *testing.T) {
 // helper function that will setup a temporary workspace.
 // to which we can clone the repositroy
 func setup() string {
-	dir, _ := os.MkdirTemp("/tmp", "plugin_git_test_")
+	dir, _ := os.MkdirTemp("", "plugin_git_test_")
 	os.Mkdir(dir, 0o777)
 	return dir
 }
@@ -655,6 +668,13 @@ func setup() string {
 // helper function to delete the temporary workspace.
 func teardown(dir string) {
 	os.RemoveAll(dir)
+}
+
+func disableAutoCRLF(t *testing.T) {
+	t.Helper()
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "core.autocrlf")
+	t.Setenv("GIT_CONFIG_VALUE_0", "false")
 }
 
 // helper function to read a file in the temporary worskapce.


### PR DESCRIPTION
When an agent uses the local backend, clone credentials live in an isolated home directory that the agent points `HOME` at. The plugin resolved its default home via `xdg.Home`, which on Windows resolves the `Profile` known folder (`%USERPROFILE%`) and ignores `HOME` entirely — so it overrode `HOME` for every git command with the real user profile, where those credentials don't exist. Cloning a private repo failed with a 401 and fell through to a credential prompt.

Default `home` to `$HOME`, falling back to `os.UserHomeDir()`. Drops the `github.com/adrg/xdg` dependency. No behavior change on Linux with `HOME` set — that's exactly what `xdg.Home` resolved to there.

Also included, so the suite passes on Windows:
- `os.TempDir()` instead of the hardcoded `/tmp`.
- Tests: `os.TempDir()` / `os.MkdirTemp("")` instead of `/tmp`, pin `core.autocrlf=false` for the clone tests, skip the two umask tests on Windows (umask is a no-op there).